### PR TITLE
Fix #141: SQLA 0.7 compatibility for index column names

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -1,6 +1,7 @@
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy import schema as sa_schema, types as sqltypes
 import logging
+from ..compat import get_index_column_names
 from .render import _render_server_default
 from sqlalchemy.util import OrderedSet
 
@@ -258,7 +259,7 @@ def _compare_indexes(schema, tname, object_filters, conn_table,
         diffs.append(("add_index", meta))
         log.info("Detected added index '%s' on %s",
             key, ', '.join([
-                "'%s'" % y.name for y in meta.expressions
+                "'%s'" % get_index_column_names(meta)
                 ])
         )
 
@@ -271,8 +272,8 @@ def _compare_indexes(schema, tname, object_filters, conn_table,
         conn_index = c_objs[key]
         # TODO: why don't we just render the DDL here
         # so we can compare the string output fully
-        conn_exps = [exp.name for exp in conn_index.expressions]
-        meta_exps = [exp.name for exp in meta_index.expressions]
+        conn_exps = get_index_column_names(conn_index)
+        meta_exps = get_index_column_names(meta_index)
 
         # convert between both Nones (SQLA ticket #2825) on the metadata
         # side and zeroes on the reflection side.

--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 
-from ..compat import string_types
+from ..compat import string_types, get_index_column_names
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def _add_index(index, autogen_context):
     text = "op.create_index('%(name)s', '%(table)s', %(columns)s, unique=%(unique)r%(schema)s%(kwargs)s)" % {
         'name': index.name,
         'table': index.table,
-        'columns': [exp.name for exp in index.expressions],
+        'columns': get_index_column_names(index),
         'unique': index.unique or False,
         'schema': (", schema='%s'" % index.table.schema) if index.table.schema else '',
         'kwargs': (', '+', '.join(

--- a/alembic/compat.py
+++ b/alembic/compat.py
@@ -1,4 +1,5 @@
 import sys
+from sqlalchemy import __version__ as sa_version
 
 if sys.version_info < (2, 6):
     raise NotImplementedError("Python 2.6 or greater is required.")
@@ -56,14 +57,19 @@ else:
         finally:
             fp.close()
 
-
-
 try:
     exec_ = getattr(compat_builtins, 'exec')
 except AttributeError:
     # Python 2
     def exec_(func_text, globals_, lcl):
         exec('exec func_text in globals_, lcl')
+
+if sa_version >= '0.8.0':
+    def get_index_column_names(idx):
+        return [exp.name for exp in idx.expressions]
+else:
+    def get_index_column_names(idx):
+        return [col.name for col in idx.columns]
 
 ################################################
 # cross-compatible metaclass implementation


### PR DESCRIPTION
Added `alembic.compat.get_index_column_names`.

https://bitbucket.org/zzzeek/alembic/issue/141/need-to-use-indexcolumns-w-sqla-07
