### PR TITLE
Add EnvironmentContext and Config to MigrationContext

### DIFF
--- a/alembic/environment.py
+++ b/alembic/environment.py
@@ -661,6 +661,7 @@ class EnvironmentContext(object):
             connection=connection,
             url=url,
             dialect_name=dialect_name,
+            environment_context=self,
             opts=opts
         )
 

--- a/alembic/migration.py
+++ b/alembic/migration.py
@@ -58,7 +58,8 @@ class MigrationContext(object):
         op.alter_column("mytable", "somecolumn", nullable=True)
 
     """
-    def __init__(self, dialect, connection, opts):
+    def __init__(self, dialect, connection, opts, environment_context=None):
+        self.environment_context = environment_context
         self.opts = opts
         self.dialect = dialect
         self.script = opts.get('script')
@@ -115,6 +116,7 @@ class MigrationContext(object):
                 connection=None,
                 url=None,
                 dialect_name=None,
+                environment_context=None,
                 opts={},
     ):
         """Create a new :class:`.MigrationContext`.
@@ -148,7 +150,7 @@ class MigrationContext(object):
         else:
             raise Exception("Connection, url, or dialect_name is required.")
 
-        return MigrationContext(dialect, connection, opts)
+        return MigrationContext(dialect, connection, opts, environment_context)
 
 
     def begin_transaction(self, _per_migration=False):
@@ -304,6 +306,14 @@ class MigrationContext(object):
 
         """
         return self.connection
+
+    @property
+    def config(self):
+        """Return the :class:`.Config` used by the current environment, if any."""
+        if self.environment_context:
+            return self.environment_context.config
+        else:
+            return None
 
     def _compare_type(self, inspector_column, metadata_column):
         if self._user_compare_type is False:


### PR DESCRIPTION
My use case is that in my migrations, I want to be able to execute SQL that uses a schema name and the schema name is something that will be configured differently depending on the user or CI or deployment system that is running.

I modified the code so that the `MigrationContext` has access to the `EnvironmentContext` and the config (which comes from `alembic.ini).

This lets migrations do stuff like:

``` python
# 13189a2dd36_populate_stuff.py

...
schema = op.get_context().config.get_main_option('schema')
...
def downgrade():
    print("downgrade (%r): schema = %r" % (revision, schema))
    op.execute("""
        TRUNCATE TABLE {schema}.FooTable;
        """.format(schema=schema))
```

where `schema` is a custom option that I added to `alembic.ini`

``` ini
# alembic.ini

...
sqlalchemy.url = mssql+pymssql://...
schema = foobar_schema
...
```
