### PR TITLE
.gitignore: .egg-info => *.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ dist/
 alembic.ini
 tox.ini
 .venv
-.egg-info
+*.egg-info
 .coverage


### PR DESCRIPTION
Without this, I was getting this:

```
$ git status
On branch add_env_context_and_config_to_migration_context
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    alembic.egg-info/

nothing added to commit but untracked files present (use "git add" to track)
```
