### PR TITLE
Eliminate {} (dict) default arg value for `opts`

### DIFF
--- a/alembic/migration.py
+++ b/alembic/migration.py
@@ -117,7 +117,7 @@ class MigrationContext(object):
                 url=None,
                 dialect_name=None,
                 environment_context=None,
-                opts={},
+                opts=None,
     ):
         """Create a new :class:`.MigrationContext`.
 
@@ -139,6 +139,9 @@ class MigrationContext(object):
          this dictionary.
 
         """
+        if opts is None:
+            opts = {}
+
         if connection:
             dialect = connection.dialect
         elif url:


### PR DESCRIPTION
to `MigrationContext.configure`

Using a mutable type as a default value is a common source of obscure
problems.

See
http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments
