### PR TITLE
Populate EnvironmentContext with alembic.ini config

### DIFF
--- a/alembic/environment.py
+++ b/alembic/environment.py
@@ -624,7 +624,8 @@ class EnvironmentContext(object):
          semicolon between statements like most other backends.
 
         """
-        opts = self.context_opts
+        opts = self.config.get_section(self.config.config_ini_section)
+        opts.update(self.context_opts)
         if transactional_ddl is not None:
             opts["transactional_ddl"] = transactional_ddl
         if output_buffer is not None:


### PR DESCRIPTION
because I want to be able to set `version_table_schema` in `alembic.ini`
and have it propagate.

Previously, I had to have the following in my `env.py`:

``` python
def run_migrations_online():
    """Run migrations in 'online' mode.

    In this scenario we need to create an Engine
    and associate a connection with the context.

    """
    engine = engine_from_config(
                config.get_section(config.config_ini_section),
                prefix='sqlalchemy.',
                poolclass=pool.NullPool)

    connection = engine.connect()
    alembic_ini_config_dict = config.get_section(config.config_ini_section)  # <-- Stuff I added
    context.configure(
                connection=connection,
                target_metadata=target_metadata,
                **alembic_ini_config_dict  # <-- Stuff I added
                )

    try:
        with context.begin_transaction():
            context.run_migrations()
    finally:
        connection.close()
```

With the changes in this PR, I can use the value in `alembic.ini` without having to hack my `env.py` file.
