### PR TITLE
[WIP] Add include_branch arg to 'current' function

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -302,7 +302,7 @@ def branches(config, verbose=False):
             )
 
 
-def current(config, verbose=False, head_only=False):
+def current(config, verbose=False, head_only=False, include_branches=False):
     """Display the current revision for a database."""
 
     script = ScriptDirectory.from_config(config)
@@ -317,7 +317,7 @@ def current(config, verbose=False, head_only=False):
                 util.obfuscate_url_pw(context.connection.engine.url)
             )
         for rev in script.get_revisions(rev):
-            config.print_stdout(rev.cmd_format(verbose))
+            config.print_stdout(rev.cmd_format(verbose, include_branches=include_branches))
         return []
 
     with EnvironmentContext(


### PR DESCRIPTION
This commit updates the 'current' function in alembic/command.py by
adding include_branches argument.  With this in place, we then pass
include_branch to the 'cmd_format' call inside 'current'.

This is being implemented to help solve [1].  OpenStack Neutron uses
multiple alembic branches and as a deployer I would like to use
'neutron-db-manage current' (which is leveraging alembic's 'current')
to determine which revision is associated with which branch so I can
selectively apply migrations for each branch.  This is necessary as one
branch can have migrations run while neutron-server is running while the
other should be run with neutron-server stopped.

I am not familiar w/ alembic, so please let me know if this change is
inappropriate or if there is a better way to achieve the desired
result.

[1] https://bugs.launchpad.net/neutron/+bug/1488021