### PR TITLE
Misleading 'else' clauses on loops.

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -317,8 +317,8 @@ class AutogenContext(object):
         for fn in self._object_filters:
             if not fn(object_, name, type_, reflected, compare_to):
                 return False
-        else:
-            return True
+
+        return True
 
 
 class RevisionContext(object):

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -23,8 +23,8 @@ class SQLiteImpl(DefaultImpl):
         for op in batch_op.batch:
             if op[0] not in ('add_column', 'create_index', 'drop_index'):
                 return True
-        else:
-            return False
+
+        return False
 
     def add_constraint(self, const):
         # attempt to distinguish between an

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -1277,8 +1277,8 @@ class AlterColumnOp(AlterTableOp):
         for kw in self.kw:
             if kw.startswith('modify_'):
                 return True
-        else:
-            return False
+
+        return False
 
     def reverse(self):
 

--- a/alembic/testing/exclusions.py
+++ b/alembic/testing/exclusions.py
@@ -69,8 +69,8 @@ class compound(object):
         for predicate in self.skips.union(self.fails):
             if predicate(config):
                 return False
-        else:
-            return True
+
+        return True
 
     def matching_config_reasons(self, config):
         return [

--- a/alembic/testing/fixtures.py
+++ b/alembic/testing/fixtures.py
@@ -132,10 +132,10 @@ def op_fixture(
             for stmt in buf.lines:
                 if sql in stmt:
                     return
-            else:
-                assert False, "Could not locate fragment %r in %r" % (
-                    sql,
-                    buf.lines
+
+            assert False, "Could not locate fragment %r in %r" % (
+                sql,
+                buf.lines
                 )
 
     if as_sql:

--- a/alembic/util/langhelpers.py
+++ b/alembic/util/langhelpers.py
@@ -305,8 +305,8 @@ class Dispatcher(object):
             elif (spcls, 'default') in self._registry:
                 return self._fn_or_list(
                     self._registry[(spcls, 'default')])
-        else:
-            raise ValueError("no dispatch function for object: %s" % obj)
+
+        raise ValueError("no dispatch function for object: %s" % obj)
 
     def _fn_or_list(self, fn_or_list):
         if self.uselist:


### PR DESCRIPTION
These 'else' clauses on loops can be a bit misleading, see [ref](http://docs.quantifiedcode.com/python-anti-patterns/correctness/else_clause_on_loop_without_a_break_statement.html). Noticed this from pylint, which categorizes these as [useless-else-on-loop (W0120)](http://docs.pylint.org/features.html).

In this case, there was no logic bug, since the loop bodies use a `return` to break out of the loop on a match, and expect the `else` clause to be entered otherwise, but this usage is still considered [stylistically confusing](https://mail.python.org/pipermail/code-quality/2013-September/000149.html) and a waste of an 'else' clause.