### PR TITLE
Unnessary use of 'global' keyword

### DIFF
--- a/alembic/testing/plugin/plugin_base.py
+++ b/alembic/testing/plugin/plugin_base.py
@@ -137,7 +137,6 @@ def restore_important_follower_config(dict_):
     This invokes in the follower process.
 
     """
-    global db_opts, include_tags, exclude_tags
     db_opts.update(dict_['memoized_config']['db_opts'])
     include_tags.update(dict_['memoized_config']['include_tags'])
     exclude_tags.update(dict_['memoized_config']['exclude_tags'])


### PR DESCRIPTION
This use of the `global` keyword is [unnecessary](http://stackoverflow.com/a/14081324/1772673) in this spot. pylint complains about such uses as [global-variable-not-assigned](http://docs.pylint.org/features.html#id5). 