### PR TITLE
Duplicate `reraise` and `raise_from_cause` definitions.

### DIFF
--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -124,32 +124,6 @@ else:
          "    raise tp, value, tb\n")
 
     def raise_from_cause(exception, exc_info=None):
-        # not as nice as that of Py3K, but at least preserv
-        # the code line where the issue occurred
-        if exc_info is None:
-            exc_info = sys.exc_info()
-        exc_type, exc_value, exc_tb = exc_info
-        reraise(type(exception), exception, tb=exc_tb)
-
-
-if py3k:
-    def reraise(tp, value, tb=None, cause=None):
-        if cause is not None:
-            value.__cause__ = cause
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-
-    def raise_from_cause(exception, exc_info=None):
-        if exc_info is None:
-            exc_info = sys.exc_info()
-        exc_type, exc_value, exc_tb = exc_info
-        reraise(type(exception), exception, tb=exc_tb, cause=exc_value)
-else:
-    exec("def reraise(tp, value, tb=None, cause=None):\n"
-         "    raise tp, value, tb\n")
-
-    def raise_from_cause(exception, exc_info=None):
         # not as nice as that of Py3K, but at least preserves
         # the code line where the issue occurred
         if exc_info is None:


### PR DESCRIPTION
Unless I'm missing something, it sure seems like `reraise` and `raise_from_cause` are defined twice, for both the `if py3k:` case and the non-py3k case. I'm guessing some copy-paste error; one of the duplicated comment lines looks like it got truncated:

            # not as nice as that of Py3K, but at least preserv

And the identical snippet in [sqlalchemy/util/compat.py](https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/util/compat.py#L177) (perhaps the original source of this code?) doesn't redefine these functions.

I happened to notice this apparent bug from a pylint complaint about "function-redefined".