### PR TITLE
Fix pylint complaint about logging-not-lazy.

### DIFF
--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -80,9 +80,8 @@ class PostgresqlImpl(DefaultImpl):
                         log.info(
                             "Detected sequence named '%s' as "
                             "owned by integer column '%s(%s)', "
-                            "assuming SERIAL and omitting" % (
-                                seqname, table.name, colname
-                            ))
+                            "assuming SERIAL and omitting",
+                            seqname, table.name, colname)
                         # sequence, and the owner is this column,
                         # its a SERIAL - whack it!
                         del column_info['default']


### PR DESCRIPTION
Most of the logging calls ([examples](https://github.com/zzzeek/alembic/blob/master/alembic/autogenerate/compare.py#L116)) done are "lazy", letting the logging module take care of building the output string only if it needs to be output'ed. Here was one straggler which reflected to follow this rule.

Pointed out by pylint as [logging-not-lazy](http://docs.pylint.org/features.html#id25).