### PR TITLE
sqla_094 being imported twice.

### DIFF
--- a/alembic/util/__init__.py
+++ b/alembic/util/__init__.py
@@ -8,7 +8,7 @@ from .pyfiles import (  # noqa
     pyc_file_from_path, load_python_file, edit)
 from .sqla_compat import (  # noqa
     sqla_07, sqla_079, sqla_08, sqla_083, sqla_084, sqla_09, sqla_092,
-    sqla_094, sqla_094, sqla_099, sqla_100, sqla_105)
+    sqla_094, sqla_099, sqla_100, sqla_105)
 
 
 class CommandError(Exception):


### PR DESCRIPTION
`sqla_094` was being imported twice here, per complaint from pylint about [reimported](http://docs.pylint.org/features.html#id3).