### PR TITLE
Avoid removal of default_schema when default_schema is None

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -38,9 +38,10 @@ def _produce_net_changes(autogen_context, upgrade_ops):
         schemas = set(inspector.get_schema_names())
         # replace default schema name with None
         schemas.discard("information_schema")
-        # replace the "default" schema with None
-        schemas.add(None)
-        schemas.discard(default_schema)
+        if default_schema is not None:
+            # replace the "default" schema with None
+            schemas.add(None)
+            schemas.discard(default_schema)
     else:
         schemas = [None]
 


### PR DESCRIPTION
I'm not sure if this is intended behavior or not