### PR TITLE
make imports happen at the top of the file for the generated migration files

### DIFF
--- a/alembic/templates/generic/script.py.mako
+++ b/alembic/templates/generic/script.py.mako
@@ -5,16 +5,15 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
-
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
     ${upgrades if upgrades else "pass"}

--- a/alembic/templates/multidb/script.py.mako
+++ b/alembic/templates/multidb/script.py.mako
@@ -8,6 +8,9 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
@@ -15,9 +18,6 @@ down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade(engine_name):
     globals()["upgrade_%s" % engine_name]()

--- a/alembic/templates/pylons/script.py.mako
+++ b/alembic/templates/pylons/script.py.mako
@@ -5,6 +5,9 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
@@ -12,9 +15,6 @@ down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
     ${upgrades if upgrades else "pass"}


### PR DESCRIPTION
### Problem

The mako `script.py.mako` imports `sqlalchemy` and `alembic` in the middle of the file instead of the top. This is a PEP8 style violation.

### Solution

Modify the script so the imports happen at the top. 