### PR TITLE
Hashable and comparable Revision instances

### DIFF
--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -82,8 +82,17 @@ class ScriptDirectory(object):
         else:
             paths = [self.versions]
 
+        dupes = set()
         for vers in paths:
             for file_ in os.listdir(vers):
+                fullname = os.path.normpath(os.path.realpath(file_))
+                if fullname in dupes:
+                    util.warn(
+                        "File %s loaded twice! ignoring. Please ensure "
+                        "version_locations is unique.".format(fullname)
+                    )
+                    continue
+                dupes.add(fullname)
                 script = Script._from_filename(self, vers, file_)
                 if script is None:
                     continue

--- a/alembic/testing/env.py
+++ b/alembic/testing/env.py
@@ -115,7 +115,7 @@ datefmt = %%H:%%M:%%S
 
 
 
-def _multi_dir_testing_config(sourceless=False):
+def _multi_dir_testing_config(sourceless=False, extra_version_location=''):
     dir_ = os.path.join(_get_staging_directory(), 'scripts')
     url = "sqlite:///%s/foo.db" % dir_
 
@@ -124,7 +124,7 @@ def _multi_dir_testing_config(sourceless=False):
 script_location = %s
 sqlalchemy.url = %s
 sourceless = %s
-version_locations = %%(here)s/model1/ %%(here)s/model2/ %%(here)s/model3/
+version_locations = %%(here)s/model1/ %%(here)s/model2/ %%(here)s/model3/ %s
 
 [loggers]
 keys = root
@@ -149,7 +149,8 @@ keys = generic
 [formatter_generic]
 format = %%(levelname)-5.5s [%%(name)s] %%(message)s
 datefmt = %%H:%%M:%%S
-    """ % (dir_, url, "true" if sourceless else "false"))
+    """ % (dir_, url, "true" if sourceless else "false",
+           extra_version_location))
 
 
 def _no_sql_testing_config(dialect="postgresql", directives=""):


### PR DESCRIPTION
Implemented __hash__ and __cmp__ methods to avoid duplicates in
branch labels set when different branches depend on same revision.

```
(base) ------> A ---> B ------> C
                      ^^
                      | \  (depends_on)
                      |  \
(branch_X) --> K -----(--> L
                      |
                      | (depends_on)     
(branch_Y) --> O ---> P
```