### PR TITLE
add generate_revision_from_script to autogenerate.api

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -182,8 +182,17 @@ def _render_migration_diffs(context, template_args):
 
 
 def generate_revision_from_script(config, migration_script):
+    """Generate a revision from a provided :class:`.MigrationScript`
+
+    :param config: a :class:`.Config` instance.
+    :param migration_script: a :class:`.MigrationScript`
+     instance.
+    """
     from ..script import ScriptDirectory
+
     script_directory = ScriptDirectory.from_config(config)
+
+    migration_script.rev_id = util.rev_id()
 
     command_args = dict(
         message=migration_script.message,
@@ -193,7 +202,7 @@ def generate_revision_from_script(config, migration_script):
         splice=migration_script.splice,
         branch_label=migration_script.branch_label,
         version_path=migration_script.version_path,
-        rev_id=util.rev_id(),
+        rev_id=migration_script.rev_id,
         depends_on=migration_script.depends_on
     )
 
@@ -207,13 +216,10 @@ def generate_revision_from_script(config, migration_script):
             'user_module_prefix': None,
         }, autogenerate=False)
 
-    revision_context.generated_revisions[0].upgrade_ops = migration_script.upgrade_ops
-    revision_context.generated_revisions[0].downgrade_ops = migration_script.downgrade_ops
-    revision_context.generated_revisions[0]._needs_render = True
+    migration_script._needs_render = True
+    revision_context.generated_revisions[0] = migration_script
 
-    migration_script = revision_context.generated_revisions[0]
-
-    return revision_context._to_script(migration_script)
+    return revision_context._to_script(revision_context.generated_revisions[0])
 
 
 class AutogenContext(object):

--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -181,7 +181,12 @@ def _render_migration_diffs(context, template_args):
     )
 
 
-def generate_revision_from_script(config, migration_script):
+def generate_revision_from_script(
+    config,
+    migration_script,
+    sqlalchemy_module_prefix='sa.',
+    alembic_module_prefix='op.',
+):
     """Generate a revision from a provided :class:`.MigrationScript`
 
     :param config: a :class:`.Config` instance.
@@ -211,8 +216,8 @@ def generate_revision_from_script(config, migration_script):
 
     revision_context._last_autogen_context = AutogenContext(
         None, opts={
-            'sqlalchemy_module_prefix': 'sa.',
-            'alembic_module_prefix': 'op.',
+            'sqlalchemy_module_prefix': sqlalchemy_module_prefix,
+            'alembic_module_prefix': alembic_module_prefix,
             'user_module_prefix': None,
         }, autogenerate=False)
 


### PR DESCRIPTION
allows a revision to be generated against a provided migration_script (it seemed more appropriate to define a new function rather than tweak the render_python_code helper)

Ex:
```python
from alembic.autogenerate import api
from alembic.config import Config
from alembic.operations import ops
import sqlalchemy as sa
import os

config = Config(os.environ['ALEMBIC_CONFIG'])

migration_script = ops.MigrationScript(
    rev_id=None,
    message='add test table',
    upgrade_ops=ops.UpgradeOps(
        ops=[
            ops.CreateTableOp(
                'test_table',
                [
                    sa.Column('id', sa.Integer(), primary_key=True),
                    sa.Column('name', sa.String(50), nullable=False)
                ]
            ),
        ]
    ),
    downgrade_ops=ops.DowngradeOps(
        ops=[
            ops.DropTableOp('test_table')
        ]
    ),
)

api.generate_revision_from_script(config, migration_script) 
```
