### PR TITLE
Check rev subset of heads

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -376,8 +376,8 @@ class RevisionContext(object):
             if self.command_args['sql']:
                 raise util.CommandError(
                     "Using --sql with --autogenerate does not make any sense")
-            if set(self.script_directory.get_revisions(rev)) != \
-                    set(self.script_directory.get_revisions("heads")):
+            if not set(self.script_directory.get_revisions(rev)).issubset(
+                    set(self.script_directory.get_revisions("heads"))):
                 raise util.CommandError("Target database is not up to date.")
 
         upgrade_token = migration_context.opts['upgrade_token']


### PR DESCRIPTION
I'm running multiple bases and when I use autogenerate I get the `"Target database is not up to date"` error because `get_revisions(rev)` returns a tuple with just the single revision while `get_revisions("heads")` returns a tuple with the head of each base.  

Checking that the former is a subset of the latter rather than checking for equality solves this issue.  I suspect you have a reason for using equality here and/or this issue is due to my particular setup where each of my bases is associated with a different metadata.