### PR TITLE
[ticket_307-hack1]

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -6,7 +6,7 @@ from ..util.compat import string_types
 from .. import util
 from mako.pygen import PythonPrinter
 from ..util.compat import StringIO
-
+import autopep8
 
 MAX_PYTHON_ARGS = 255
 
@@ -66,7 +66,7 @@ def _render_cmd_body(op_container, autogen_context):
 
     printer.writeline("# ### end Alembic commands ###")
 
-    return buf.getvalue()
+    return autopep8.fix_code(buf.getvalue())
 
 
 def render_op(autogen_context, op):

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -2037,4 +2037,3 @@ class MigrationScript(MigrateOperation):
 
         """
         return self._downgrade_ops
-

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requires = [
     'SQLAlchemy>=0.7.6',
     'Mako',
     'python-editor>=0.3',
+    'autopep8>=1.2.4'
 ]
 
 try:


### PR DESCRIPTION
This forces alembic to support pep8 by a brute force, it just takes the output of the render command and feeds into autopep8.  Maybe not the solution you all would like,

I'm looking into diving a little deeper and wrapping the output of the dispatcher / render function to specifically address the main issue I was having being nested commands not complying with visual indent.  This patch solved all the issues I was having for my use-cases though with fairly minimal effort, hope its helpful.