### PR TITLE
Change schema render as repr on autogenerate drop constraint

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -275,7 +275,7 @@ def _drop_constraint(autogen_context, op):
             autogen_context, op.constraint_name),
         'table_name': _ident(op.table_name),
         'type': op.constraint_type,
-        'schema': (", schema='%s'" % _ident(op.schema))
+        'schema': (", schema=%r" % _ident(op.schema))
         if op.schema else '',
     }
     return text


### PR DESCRIPTION
Hello, i am trying generate migrations with schema as module, and find this issue.

This code generate migrations well, but without fix skip drop constraints :(
```python
from alembic.autogenerate import comparators

class SchemaAsModule(str):
    def __repr__(self):
        if 'pro' in self:
            return 'pro.schema'
        elif 'meta' in self:
            return 'meta.schema'
        raise RuntimeError('Wrong Schema')


@comparators.dispatch_for("table")
def compare_table_level(**kwargs):
    table = kwargs['conn_table']
    table.schema = SchemaAsModule(table.schema)

    for op in kwargs['modify_ops'].ops:
        if hasattr(op, 'schema'):
            op.schema = SchemaAsModule(op.schema)


@comparators.dispatch_for("schema")
def compare_sequences(**kwargs):
    for op in kwargs['upgrade_ops'].ops:
        op.schema = SchemaAsModule(op.schema)


def run_migrations_online():
    """Run migrations in 'online' mode.

    In this scenario we need to create an Engine
    and associate a connection with the context.

    """
    connectable = create_engine(ALEMBIC_URL, poolclass=pool.NullPool)

    for m in target_metadata:
        m.schema = SchemaAsModule(m.schema)
        for t in m.tables.values():
            t.schema = SchemaAsModule(t.schema)

    with connectable.connect() as connection:
        context.configure(
            connection=connection,
            target_metadata=target_metadata,
            include_schemas=True,
        )

        with context.begin_transaction():
            context.run_migrations()
```

Migration without fix:
```python
...
def upgrade():
    op.drop_constraint('snip', 'snip', schema='real_schema', type_='foreignkey')
    op.drop_constraint('snip', 'snip', schema='real_schema', type_='foreignkey')
    op.create_foreign_key(None, 'snip', 'snip', ['snip'], ['snip'], source_schema=meta.schema, referent_schema=meta.schema, onupdate=u'CASCADE', ondelete=u'CASCADE')
    op.create_foreign_key(None, 'snip', 'snip', ['snip'], ['snip'], source_schema=meta.schema, referent_schema=meta.schema)
    op.alter_column('snip', 'locales',
               existing_type=mysql.VARCHAR(length=255),
               nullable=True,
               schema=pro.schema)
```

Result migration with fix:
```python
...
def upgrade():
    op.drop_constraint('snip', 'snip', schema=meta.schema, type_='foreignkey')
    op.drop_constraint('snip', 'snip', schema=meta.schema, type_='foreignkey')
    op.create_foreign_key(None, 'snip', 'snip', ['snip'], ['snip'], source_schema=meta.schema, referent_schema=meta.schema, onupdate=u'CASCADE', ondelete=u'CASCADE')
    op.create_foreign_key(None, 'snip', 'snip', ['snip'], ['accountname'], source_schema=meta.schema, referent_schema=meta.schema)
    op.alter_column('snip', 'snip'
               existing_type=mysql.VARCHAR(length=255),
               nullable=True,
               schema=pro.schema)
    ...
```
