### PR TITLE
Formatting output twice causes ValueError

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -153,11 +153,27 @@ class Config(object):
         return {}
 
     def print_stdout(self, text, *arg):
-        """Render a message to standard out."""
+        """Render a message to standard out.
+
+        When :meth:`.Config.print_stdout` is called with additional args
+        those arguments will formatted against the provided text,
+        otherwise we simply output the provided text verbatim.
+
+        Example:
+
+            >>> config.print_stdout('Some text %s', 'arg')
+            Some Text arg
+
+        """
+
+        if arg:
+            output = (compat.text_type(text) % arg)
+        else:
+            output = compat.text_type(text)
 
         util.write_outstream(
             self.stdout,
-            (compat.text_type(text) % arg),
+            output,
             "\n"
         )
 

--- a/alembic/testing/env.py
+++ b/alembic/testing/env.py
@@ -283,9 +283,9 @@ def downgrade():
 
     script.generate_revision(b, "revision b", refresh=True)
     write_script(script, b, u("""# coding: utf-8
-"Rev B, méil"
-revision = '%s'
-down_revision = '%s'
+"Rev B, méil, %3"
+revision = '{}'
+down_revision = '{}'
 
 from alembic import op
 
@@ -297,7 +297,7 @@ def upgrade():
 def downgrade():
     op.execute("DROP STEP 2")
 
-""") % (b, a), encoding="utf-8")
+""").format(b, a), encoding="utf-8")
 
     script.generate_revision(c, "revision c", refresh=True)
     write_script(script, c, """\

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,6 +137,15 @@ class StdoutOutputEncodingTest(TestBase):
             [call.write('m?il x y'), call.write('\n')]
         )
 
+    def test_only_formats_output_with_args(self):
+        stdout = Mock(encoding=None)
+        cfg = config.Config(stdout=stdout)
+        cfg.print_stdout(compat.u("test 3%"))
+        eq_(
+            stdout.mock_calls,
+            [call.write('test 3%'), call.write('\n')]
+        )
+
 
 class TemplateOutputEncodingTest(TestBase):
     def setUp(self):


### PR DESCRIPTION
Fixes 497

https://bitbucket.org/zzzeek/alembic/issues/497/history-command-raises-valueerror-if

When a revision description contains characters like %, writing output
to stdout will fail because the call to config.print_stdout attempted
to format any additional args passed to the function.

This fix now only applies string formatting if any args are provided
along with the output text.