### PR TITLE
Replace set union_update() references with update()

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -395,7 +395,7 @@ class RevisionContext(object):
             # renders
             autogen_context.imports = set()
             if migration_script.imports:
-                autogen_context.imports.union_update(migration_script.imports)
+                autogen_context.imports.update(migration_script.imports)
             render._render_python_into_templatevars(
                 autogen_context, migration_script, template_args
             )


### PR DESCRIPTION
The autogenerate api references the `union_update()` method of sets which was removed in Python 2.4. The previous method is actually an alias for the `update()` method.

This PR replaces the api reference with the correct one for Python 2.7